### PR TITLE
(indent-guide-global-mode): use derived-mode-p instead of memq

### DIFF
--- a/indent-guide.el
+++ b/indent-guide.el
@@ -72,6 +72,9 @@
 
 (defconst indent-guide-version "2.1.6")
 
+(eval-when-compile
+  (require 'cl-lib))
+
 ;; * customs
 
 (defgroup indent-guide nil
@@ -279,7 +282,7 @@ the point."
 (define-globalized-minor-mode indent-guide-global-mode
   indent-guide-mode
   (lambda ()
-    (unless (memq major-mode indent-guide-inhibit-modes)
+    (unless (cl-some 'derived-mode-p indent-guide-inhibit-modes)
       (indent-guide-mode 1))))
 
 ;; * provide


### PR DESCRIPTION
I see no good reason someone would want to inhibit indent-guide in some major modes but not in their derived versions. Hence my suggestion.
