### PR TITLE
Fix :group for customisation

### DIFF
--- a/indent-guide.el
+++ b/indent-guide.el
@@ -80,7 +80,7 @@
 
 (defgroup indent-guide nil
   "Show vertical lines to guide indentation."
-  :group 'emacs)
+  :group 'environment)
 
 (defcustom indent-guide-char "|"
   "Character used as vertical line."


### PR DESCRIPTION
It's not good practice to create new top-level customisation groups: 'environment is the best fit here.