### PR TITLE
Fix indent-guide-face

### DIFF
--- a/indent-guide.el
+++ b/indent-guide.el
@@ -114,7 +114,7 @@
   :type 'number
   :group 'indent-guide)
 
-(defface indent-guide-face '((t (:foreground "#535353")))
+(defface indent-guide-face '((t (:foreground "#535353" :slant normal)))
   "Face used to indent guide lines."
   :group 'indent-guide)
 


### PR DESCRIPTION
Avoiding effect of the face of inheritance, always to erect a glyph.

### Before

![2016-09-13 11 11 26](https://cloud.githubusercontent.com/assets/822086/18477361/61df8e02-7a08-11e6-93bc-8195d3184128.png)

### After

![2016-09-13 11 10 16](https://cloud.githubusercontent.com/assets/822086/18477360/6057d742-7a08-11e6-85ff-e3a3b2cebad9.png)
