### PR TITLE
indent-guide.el: Remove two docstring indentations

### DIFF
--- a/indent-guide.el
+++ b/indent-guide.el
@@ -106,13 +106,13 @@
 
 (defcustom indent-guide-delay nil
   "When a positive number, rendering guide lines is delayed DELAY
-  seconds."
+seconds."
   :type 'number
   :group 'indent-guide)
 
 (defcustom indent-guide-threshold -1
   "Guide lines are drawn only when the column number is over this
-  value."
+value."
   :type 'number
   :group 'indent-guide)
 


### PR DESCRIPTION
#### Before:
```
When a positive number, rendering guide lines is delayed DELAY
  seconds.
```
```
Guide lines are drawn only when the column number is over this
  value.
```
#### After:
```
When a positive number, rendering guide lines is delayed DELAY
seconds.
```
```
Guide lines are drawn only when the column number is over this
value.
```