### PR TITLE
Inhibit indent-guide in helm buffers

### DIFF
--- a/indent-guide.el
+++ b/indent-guide.el
@@ -105,6 +105,7 @@
     dired-mode
     eww-mode
     eshell-mode
+    helm-major-mode
     Custom-mode)
   "List of major-modes in which indent-guide should be turned off."
   :type '(repeat symbol)


### PR DESCRIPTION
## Problem

With `indent-guide-global-mode` enabled, helm buffers (`helm-mini`, completion frames, helm-dired, …) get `indent-guide-mode` turned on and then fail with `Args out of range`, leaving an empty/broken helm frame.

## Cause

`indent-guide-global-mode`'s turn-on function only inhibits a buffer when `(cl-some #'derived-mode-p indent-guide-inhibit-modes)` is non-nil. `helm-major-mode` is marked special **only** through its `mode-class` symbol property and has no `derived-mode-parent`, so `derived-mode-p` — which walks the parent chain, not `mode-class` — never matches it against `special-mode`. helm buffers therefore slip past `indent-guide-inhibit-modes` and indent-guide tries to draw guides in them.

This is the same class of issue that led to `dired-mode`, `eww-mode`, `eshell-mode`, and `Custom-mode` being added to `indent-guide-inhibit-modes` individually.

## Fix

Add `helm-major-mode` to the default `indent-guide-inhibit-modes`, matching those existing entries. One-line change; no behavior change for any other mode. Manual `M-x indent-guide-mode` is unaffected (it doesn't consult the inhibit list), so anyone who explicitly wants guides in a helm buffer still gets them.

## Testing

In a live Emacs daemon with `indent-guide-global-mode` enabled:

- **before:** a `helm-major-mode` buffer gets `indent-guide-mode` turned on (→ the crash)
- **after:** the buffer is inhibited (`indent-guide-mode` stays off), while a normal `prog-mode` buffer still receives guides (no regression)

Originally reported downstream at syl20bnr/spacemacs#17242.